### PR TITLE
fix(security): patch OS CVEs and suppress unfixable AWS JAR alerts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,7 @@ jobs:
         image-ref: docker.io/saidsef/aws-dynamodb-local:${{ env.TAG == 'main' && 'latest' || env.TAG }}
         format: 'sarif'
         output: 'trivy-results.sarif'
+        trivyignores: .trivyignore
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4
       continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,7 @@ jobs:
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
+        trivyignores: .trivyignore
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4
       with:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,21 @@
+# CVEs in AWS-bundled JARs inside amazon/dynamodb-local that cannot be patched externally.
+# These are in DynamoDBLocal_lib (Netty, Jetty, Jackson, Kotlin) and must be fixed by AWS upstream.
+CVE-2022-24329
+CVE-2025-59419
+CVE-2025-67735
+CVE-2026-1605
+CVE-2026-2332
+CVE-2026-33870
+CVE-2026-33871
+CVE-2026-41417
+CVE-2026-42578
+CVE-2026-42579
+CVE-2026-42580
+CVE-2026-42581
+CVE-2026-42583
+CVE-2026-42584
+CVE-2026-42585
+CVE-2026-42586
+CVE-2026-42587
+CVE-2026-44248
+GHSA-72hv-8253-57qq

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Said Sef <said@saidsef.co.uk> (saidsef.co.uk/)"
 
 LABEL "uk.co.saidsef.aws-dynamodb"="Said Sef Associates Ltd"
 
-ENV PROMETHEUS_JMX_JAR_VERSION 0.20.0
+ENV PROMETHEUS_JMX_JAR_VERSION="0.20.0"
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PROMETHEUS_JMX_JAR_VERSION 0.20.0
 
 USER root
 
-RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN dnf upgrade -y && dnf clean all
 
 USER dynamodblocal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ LABEL "uk.co.saidsef.aws-dynamodb"="Said Sef Associates Ltd"
 
 ENV PROMETHEUS_JMX_JAR_VERSION 0.20.0
 
+USER root
+
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER dynamodblocal
+
 WORKDIR /home/dynamodblocal
 
 COPY prometheus-jmx-config.yaml /home/dynamodblocal/

--- a/charts/dynamodb/Chart.yaml
+++ b/charts/dynamodb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: &appVersion "2026.5.0"
+appVersion: &appVersion "2026.5.1"
 description: A DynamoDB Local Helm chart for Kubernetes
 kubeVersion: ">= 1.23"
 name: dynamodb
@@ -28,5 +28,7 @@ annotations:
     - name: CONTRIBUTING
       url: https://github.com/saidsef/aws-dynamodb-local/blob/main/CONTRIBUTING.md
   artifacthub.io/changes: |
-    - kind: added
-      description: Added Chart documentation
+    - kind: security
+      description: Patch OS-level CVEs by running apt-get upgrade in Dockerfile
+    - kind: security
+      description: Suppress unfixable AWS-bundled JAR CVEs via .trivyignore


### PR DESCRIPTION
## What

Two separate problems, handled separately.

**OS-level CVEs** - the base image has unpatched packages. Fixed by running `dnf upgrade -y` in the Dockerfile (as root, then dropping back to `dynamodblocal`). Also switched from `apt-get` to `dnf` since the base is Amazon Linux 2023.

**AWS JAR CVEs** - Trivy flags vulnerabilities inside `DynamoDBLocal_lib` (Netty, Jetty, Jackson, Kotlin bundled by AWS). These can't be patched from the outside - the fix has to come from AWS upstream. Added a `.trivyignore` to suppress them so they don't drown out real findings.

Both Trivy workflows (`docker.yml`, `security.yml`) now point at `.trivyignore`.

## Changes

- `Dockerfile`: run `dnf upgrade -y` to pull in OS patches; quote the `ENV` value
- `.trivyignore`: suppress 20 CVEs/GHSAs that live inside AWS-bundled JARs
- `.github/workflows/docker.yml`, `security.yml`: pass `trivyignores: .trivyignore`
- `charts/dynamodb/Chart.yaml`: bump to `2026.5.1`, update changelog

## Notes

The ignored CVEs are tracked in `.trivyignore` with a comment explaining why they're there. If AWS ships an updated `dynamodb-local` image that fixes them, the entries can be removed and Trivy will start flagging them again.